### PR TITLE
Add GPIO module and Makefile configuration by Demir Hasicic

### DIFF
--- a/src/interns/demir-hasicic/GPIO.cpp
+++ b/src/interns/demir-hasicic/GPIO.cpp
@@ -1,0 +1,99 @@
+#include "GPIO.h"
+//Funkcija za aktiviranje clocka specificiranog GPIO porta // 
+void gpio_clock_init(GPIO_TypeDef* port) {
+    if (port == GPIOA) {
+        RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN;       //Aktivira se clock za GPIOA port
+    } else if (port == GPIOB) {
+        RCC->AHB1ENR |= RCC_AHB1ENR_GPIOBEN;
+    } else if (port == GPIOC) {
+        RCC->AHB1ENR |= RCC_AHB1ENR_GPIOCEN;
+    } else if (port == GPIOD) {
+        RCC->AHB1ENR |= RCC_AHB1ENR_GPIODEN;
+    } else if (port == GPIOE) {
+        RCC->AHB1ENR |= RCC_AHB1ENR_GPIOEEN;
+    } else if (port == GPIOH) {
+        RCC->AHB1ENR |= RCC_AHB1ENR_GPIOHEN;
+    } else return;
+}
+
+// Funkcija za postavljanje moda rada za određeni GPIO pin
+void gpio_mode(GPIO_TypeDef* port, PIN pin, GPIOMODE mode)
+{
+  
+        // Reset trenutnog moda rada za specificirani GPIO pin
+    port->MODER &= ~(3<<(2*static_cast<uint8_t>(pin)));
+        // Postavljanje novog moda rada za specificirani GPIO pin
+    port->MODER |= (static_cast<uint8_t>(mode)<<(2*static_cast<uint8_t>(pin)));
+}
+
+//Funkcija za postavljanje izlaznog tipa (output type) za određeni GPIO pin
+void gpio_output_type(GPIO_TypeDef* port, PIN pin, OTYPE type)
+
+{
+  
+    //Reset trenutnog izlaznog tipa za specificirani GPIO pin
+    port->OTYPER &= ~(1<<static_cast<uint8_t>(pin));
+    //Postavljanje specificiranog GPIO pina na određeni izlazni tip
+    port->OTYPER |= (static_cast<uint8_t>(type)<<static_cast<uint8_t>(pin));
+
+}
+
+//Funkcija za postavljanje brzine specificiranog GPIO pina
+void gpio_speed(GPIO_TypeDef* port, PIN pin, SPEED speed)
+
+{
+        // Resetovanje trenutne brzine specificiranog GPIO pina
+port->OSPEEDR &= ~(3<<(static_cast<uint8_t>(pin)*2));
+        // Postavljanje nove brzine specificiranog GPIO pina
+port->OSPEEDR |= (static_cast<uint8_t>(speed)<<(static_cast<uint8_t>(pin)*2));
+
+}
+
+//Funkcija za konfigurisanje pull-up ili pull-down otpornika za određeni GPIO pin
+void gpio_pull(GPIO_TypeDef* port, PIN pin, PULL pull)
+{
+    //Resetovanje bita na specificiranom GPIO pinu
+port->PUPDR &= ~(3<<(static_cast<uint8_t>(pin)*2));
+    //Postavljanje pull-up/pull-down za specificirani GPIO pin
+port->PUPDR |= (static_cast<uint8_t>(pull)<<(static_cast<uint8_t>(pin)*2));
+}
+
+//Funkcija za čitanje stanja na ulaznom pinu
+PIN_STATE gpio_read(GPIO_TypeDef* port, PIN pin) {
+  if(port->IDR & (1<<(static_cast<uint8_t>(pin)))){
+    return PIN_STATE::HIGH;
+  }
+return PIN_STATE::LOW;   
+}
+
+
+//Funkcija za postavljanje pina na HIGH //objediniti
+void gpio_write(GPIO_TypeDef* port, PIN pin)  //Brr je write-only,Koristenje &=, |=, nema smisla
+{
+port->BSRR  = (1<<(static_cast<uint8_t>(pin)));
+}
+
+//Funkcija za postavljanje pina na LOW
+void gpio_reset(GPIO_TypeDef* port, PIN pin)
+{
+port->BSRR  = (1<<(static_cast<uint8_t>(pin) + 16));
+}
+
+void gpio_AF(GPIO_TypeDef* port, PIN pin, ALT_FUNCTION alt_function)
+{
+    //Postavljanje alternativne funkcije za pinove 0-7 (AFRL)
+    if(static_cast<uint8_t>(pin)<=7){
+        //Resetovanje 4 bita za alternativne funkcije na specificiranom pinu
+        port->AFR[0] &= ~(15<<(static_cast<uint8_t>(pin)*4)); 
+        //Postavljanje alternative funkcije na specificiranom pinu 
+        port->AFR[0] |= (static_cast<uint8_t>(alt_function)<<(static_cast<uint8_t>(pin)*4));
+}
+    //Postavljanje alternativne funkcije za pinove 8-15 (AFRH)
+    else if((static_cast<uint8_t>(pin))<=15){
+        //Podešavanje offseta pina
+        uint8_t adjusted_pin = static_cast<uint8_t>(pin) - 8;
+        port->AFR[1] &= ~(15 << adjusted_pin*4);
+        port->AFR[1] |= (static_cast<uint8_t>(alt_function) << adjusted_pin*4);
+    }
+}
+

--- a/src/interns/demir-hasicic/GPIO.cpp
+++ b/src/interns/demir-hasicic/GPIO.cpp
@@ -67,16 +67,13 @@ return PIN_STATE::LOW;
 }
 
 
-//Funkcija za postavljanje pina na HIGH //objediniti
-void gpio_write(GPIO_TypeDef* port, PIN pin)  //Brr je write-only,Koristenje &=, |=, nema smisla
-{
-port->BSRR  = (1<<(static_cast<uint8_t>(pin)));
-}
-
-//Funkcija za postavljanje pina na LOW
-void gpio_reset(GPIO_TypeDef* port, PIN pin)
-{
-port->BSRR  = (1<<(static_cast<uint8_t>(pin) + 16));
+// Funkcija za postavljanje stanja GPIO pina (HIGH ili LOW)
+void gpio_set_state(GPIO_TypeDef* port, PIN pin, PIN_STATE state) {
+    if (state == PIN_STATE::HIGH) {
+        port->BSRR = (1 << static_cast<uint8_t>(pin)); // Postavlja pin na HIGH
+    } else {
+        port->BSRR = (1 << (static_cast<uint8_t>(pin) + 16)); // Postavlja pin na LOW
+    }
 }
 
 void gpio_AF(GPIO_TypeDef* port, PIN pin, ALT_FUNCTION alt_function)

--- a/src/interns/demir-hasicic/GPIO.h
+++ b/src/interns/demir-hasicic/GPIO.h
@@ -19,6 +19,5 @@ void gpio_output_type(GPIO_TypeDef* port, PIN pin, OTYPE type);
 void gpio_speed(GPIO_TypeDef* port, PIN pin, SPEED speed);
 void gpio_pull(GPIO_TypeDef* port, PIN pin, PULL pull);
 PIN_STATE gpio_read(GPIO_TypeDef* port, PIN pin);
-void gpio_write(GPIO_TypeDef* port, PIN pin);
-void gpio_reset(GPIO_TypeDef* port, PIN pin);
+void gpio_set_state(GPIO_TypeDef* port, PIN pin, PIN_STATE state)
 void gpio_AF(GPIO_TypeDef* port, PIN pin, ALT_FUNCTION alt_function);

--- a/src/interns/demir-hasicic/GPIO.h
+++ b/src/interns/demir-hasicic/GPIO.h
@@ -1,0 +1,24 @@
+#include <stdint.h>
+#include "stm32f4xx.h"
+
+enum class PIN {   
+    PIN0, PIN1, PIN2, PIN3, PIN4, PIN5, PIN6, PIN7,
+    PIN8, PIN9, PIN10, PIN11, PIN12, PIN13, PIN14, PIN15
+};
+
+enum class GPIOMODE { INPUT, OUTPUT, AFC, ANALOG };
+enum class OTYPE { PUSH_PULL, OPEN_DRAIN };
+enum class SPEED { LOW, MEDIUM, FAST, HIGH };
+enum class PULL { NO_PULL, PULL_UP, PULL_DOWN, RESERVED };
+enum class PIN_STATE { LOW, HIGH };
+enum class ALT_FUNCTION { AF0, AF1, AF2, AF3, AF4, AF5, AF6, AF7, AF8, AF9, AF10, AF11, AF12, AF13, AF14, AF15 };
+
+void gpio_clock_init(GPIO_TypeDef* port);
+void gpio_mode(GPIO_TypeDef* port, PIN pin, GPIOMODE mode);
+void gpio_output_type(GPIO_TypeDef* port, PIN pin, OTYPE type);
+void gpio_speed(GPIO_TypeDef* port, PIN pin, SPEED speed);
+void gpio_pull(GPIO_TypeDef* port, PIN pin, PULL pull);
+PIN_STATE gpio_read(GPIO_TypeDef* port, PIN pin);
+void gpio_write(GPIO_TypeDef* port, PIN pin);
+void gpio_reset(GPIO_TypeDef* port, PIN pin);
+void gpio_AF(GPIO_TypeDef* port, PIN pin, ALT_FUNCTION alt_function);

--- a/src/interns/demir-hasicic/Makefile
+++ b/src/interns/demir-hasicic/Makefile
@@ -14,11 +14,14 @@ PROGRAMMER_FLAGS = -f interface/stlink.cfg -f target/stm32f4x.cfg
 
 all: $(BINARY)
 
-$(BINARY): main.o startup.o system_stm32f4xx.o
+$(BINARY): main.o GPIO.o startup.o system_stm32f4xx.o
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $^ -o $(BINARY)
 
 main.o: main.cpp
 	$(CC) $(CFLAGS) $(CPPFLAGS) main.cpp -c
+
+GPIO.o: GPIO.cpp
+	$(CC) $(CFLAGS) $(CPPFLAGS) GPIO.cpp -c
 
 startup.o: ../../startup.cpp
 	$(CC) $(CFLAGS) $(CPPFLAGS) ../../startup.cpp -c


### PR DESCRIPTION
Includes :
- GPIO functionality in gpio.cpp and gpio.h with functions for initializing GPIO pins, setting modes, and alternate functions
- Updated Makefile to include GPIO.cpp in the build process