### PR TITLE
Add USART module and MakeFile configuration

### DIFF
--- a/src/interns/demir-hasicic/GPIO.cpp
+++ b/src/interns/demir-hasicic/GPIO.cpp
@@ -1,5 +1,5 @@
 #include "GPIO.h"
-//Funkcija za aktiviranje clocka specificiranog GPIO porta // 
+//Funkcija za aktiviranje clocka specificiranog GPIO porta 
 void gpio_clock_init(GPIO_TypeDef* port) {
     if (port == GPIOA) {
         RCC->AHB1ENR |= RCC_AHB1ENR_GPIOAEN;       //Aktivira se clock za GPIOA port
@@ -94,3 +94,15 @@ void gpio_AF(GPIO_TypeDef* port, PIN pin, ALT_FUNCTION alt_function)
     }
 }
 
+void gpio_init(GPIO_TypeDef* port, PIN pin, GPIOMODE mode, OTYPE type, SPEED speed, PULL pull, ALT_FUNCTION alt_function) {
+    gpio_clock_init(port);
+    gpio_mode(port, pin, mode);
+    gpio_output_type(port, pin, type);
+    gpio_speed(port, pin, speed);
+    gpio_pull(port, pin, pull);
+
+    // Konfigurisanje alternativne funkcije ako je odabran taj mode
+    if (mode == GPIOMODE::AFC) {
+        gpio_AF(port, pin, alt_function);
+    }
+}

--- a/src/interns/demir-hasicic/GPIO.h
+++ b/src/interns/demir-hasicic/GPIO.h
@@ -19,5 +19,6 @@ void gpio_output_type(GPIO_TypeDef* port, PIN pin, OTYPE type);
 void gpio_speed(GPIO_TypeDef* port, PIN pin, SPEED speed);
 void gpio_pull(GPIO_TypeDef* port, PIN pin, PULL pull);
 PIN_STATE gpio_read(GPIO_TypeDef* port, PIN pin);
-void gpio_set_state(GPIO_TypeDef* port, PIN pin, PIN_STATE state)
+void gpio_set_state(GPIO_TypeDef* port, PIN pin, PIN_STATE state);
 void gpio_AF(GPIO_TypeDef* port, PIN pin, ALT_FUNCTION alt_function);
+void gpio_init(GPIO_TypeDef* port, PIN pin, GPIOMODE mode, OTYPE type, SPEED speed, PULL pull, ALT_FUNCTION alt_function);

--- a/src/interns/demir-hasicic/Makefile
+++ b/src/interns/demir-hasicic/Makefile
@@ -14,14 +14,20 @@ PROGRAMMER_FLAGS = -f interface/stlink.cfg -f target/stm32f4x.cfg
 
 all: $(BINARY)
 
-$(BINARY): main.o GPIO.o startup.o system_stm32f4xx.o
+$(BINARY): main.o syscalls.o USART.o GPIO.o startup.o system_stm32f4xx.o
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $^ -o $(BINARY)
 
 main.o: main.cpp
 	$(CC) $(CFLAGS) $(CPPFLAGS) main.cpp -c
 
+syscalls.o: syscalls.cpp
+	$(CC) $(CFLAGS) $(CPPFLAGS) syscalls.cpp -c
+
 GPIO.o: GPIO.cpp
 	$(CC) $(CFLAGS) $(CPPFLAGS) GPIO.cpp -c
+
+USART.o: USART.cpp
+	$(CC) $(CFLAGS) $(CPPFLAGS) USART.cpp -c
 
 startup.o: ../../startup.cpp
 	$(CC) $(CFLAGS) $(CPPFLAGS) ../../startup.cpp -c

--- a/src/interns/demir-hasicic/USART.cpp
+++ b/src/interns/demir-hasicic/USART.cpp
@@ -56,7 +56,7 @@ void usart_set_baudrate(USART_TypeDef* usart, uint32_t baudrate)
     if(usart==USART2){
     
     //Ekstrakcija prescaler vrijednosti za APB1 bus
-    uint32_t ppre1 = (RCC->CFGR & RCC_CFGR_PPRE1_Msk);
+    uint32_t ppre1 = (RCC->CFGR & RCC_CFGR_PPRE1_Msk) >> RCC_CFGR_PPRE1_Pos;
     
     // Izračunavanje prescalera za APB1 na osnovu vrijednosti ppre1
     uint32_t apb1_prescaler = get_prescaler(static_cast<PPRE>(ppre1));    
@@ -67,7 +67,7 @@ void usart_set_baudrate(USART_TypeDef* usart, uint32_t baudrate)
     else if(usart==USART1 || usart == USART6){
     
     //Ekstrakcija prescaler vrijednosti za APB2 bus
-    uint32_t ppre2 = (RCC->CFGR & RCC_CFGR_PPRE2_Msk); 
+    uint32_t ppre2 = (RCC->CFGR & RCC_CFGR_PPRE2_Msk)>> RCC_CFGR_PPRE2_Pos;
     
     // Izračunavanje prescalera za APB2 na osnovu vrijednosti ppre2 
     uint32_t apb2_prescaler = get_prescaler(static_cast<PPRE>(ppre2));

--- a/src/interns/demir-hasicic/USART.cpp
+++ b/src/interns/demir-hasicic/USART.cpp
@@ -1,0 +1,132 @@
+#include "USART.h"
+//Funkcija za aktiviranje clocka za specificirani USART
+void usart_clock_init(USART_TypeDef* usart){
+    //USART1 se nalazi na APB2 pa je potrebno postaviti odgovarajući bit u APB2 registru
+    if(usart==USART1){
+        RCC->APB2ENR |= RCC_APB2ENR_USART1EN;
+    }
+    //USART2 se nalazi na APB1 pa je potrebno postaviti odgovarajući bit u APB1 registru
+    else if(usart==USART2){
+        RCC->APB1ENR |= RCC_APB1ENR_USART2EN;
+    }
+    //USART6 se nalazi na APB2 pa je potrebno postaviti odgovarajući bit u APB2 registru
+    else if(usart==USART6)
+    {
+        RCC->APB2ENR |= RCC_APB2ENR_USART6EN;
+    }
+}
+
+void usart_set_state(USART_TypeDef* usart, USART_STATE state) {
+    if (state == USART_STATE::ENABLE) {
+        usart->CR1 |= USART_CR1_UE;  // Uključivanje USART-a
+    } 
+    else {
+        usart->CR1 &= ~USART_CR1_UE; // Isključivanje USART-a
+    }
+}
+
+void usart_configure_oversampling(USART_TypeDef* usart, USART_OVERSAMPLING oversampling) {
+    if (oversampling == USART_OVERSAMPLING::OVERSAMPLING_8) {
+        usart->CR1 |= USART_CR1_OVER8; // Postavljanje na 8x oversampling
+    } else {
+        usart->CR1 &= ~USART_CR1_OVER8; // Postavljanje na 16x oversampling
+    }
+}
+
+//Funkcija za određivanje faktora dijeljenja na osnovu vrijednosti prescalera u registru
+uint32_t get_prescaler(PPRE ppre_value) {
+    if (ppre_value == PPRE::DIV2) {
+        return 2;  
+    } else if (ppre_value == PPRE::DIV4) {
+        return 4;  
+    } else if (ppre_value == PPRE::DIV8) {
+        return 8;  
+    } else if (ppre_value == PPRE::DIV16) {
+        return 16; 
+    } else {
+        return 1; 
+    }
+}
+
+// Funkcija za postavljanje baud rate-a za specificirani USART
+void usart_set_baudrate(USART_TypeDef* usart, uint32_t baudrate)
+{
+    uint32_t bus_frequency;
+    // Određivanje frekvencije busa na osnovu odabranog USART-a
+    if(usart==USART2){
+    
+    //Ekstrakcija prescaler vrijednosti za APB1 bus
+    uint32_t ppre1 = (RCC->CFGR & RCC_CFGR_PPRE1_Msk);
+    
+    // Izračunavanje prescalera za APB1 na osnovu vrijednosti ppre1
+    uint32_t apb1_prescaler = get_prescaler(static_cast<PPRE>(ppre1));    
+    
+    bus_frequency = SystemCoreClock/apb1_prescaler;
+    }
+
+    else if(usart==USART1 || usart == USART6){
+    
+    //Ekstrakcija prescaler vrijednosti za APB2 bus
+    uint32_t ppre2 = (RCC->CFGR & RCC_CFGR_PPRE2_Msk); 
+    
+    // Izračunavanje prescalera za APB2 na osnovu vrijednosti ppre2 
+    uint32_t apb2_prescaler = get_prescaler(static_cast<PPRE>(ppre2));
+    
+    bus_frequency = SystemCoreClock/apb2_prescaler;
+    }
+    
+    uint32_t brr;
+    
+    // Izračunavanje BRR registra na osnovu oversampling faktora
+    
+    bool is_oversampling_8 = (usart->CR1 & USART_CR1_OVER8);
+    
+        if(is_oversampling_8)
+    {
+        brr = bus_frequency / (2* baudrate);
+    }
+    else {
+        brr = bus_frequency / baudrate;
+    }
+    
+    // Postavljanje BRR registra
+    usart->BRR = brr;
+}
+
+// Funkcija za konfiguraciju načina rada USART-a
+void usart_configure_mode(USART_TypeDef* usart, USART_MODE mode) {
+    // Aktivacija transmisije
+    if (mode == USART_MODE::TRANSMIT || mode == USART_MODE::BOTH) {
+        usart->CR1 |= USART_CR1_TE; 
+    }
+    // Aktivacija prijema
+    if (mode == USART_MODE::RECEIVE || mode == USART_MODE::BOTH) {
+        usart->CR1 |= USART_CR1_RE; 
+    }
+}
+
+void usart_write_byte(USART_TypeDef* usart, uint8_t byte)
+{	        
+    //Čekanje dok TXE postane prazan
+    while(!(usart->SR & USART_SR_TXE));
+	usart->DR = byte;
+}
+
+void usart_write_buffer(USART_TypeDef* usart, char *ptr, int len) {
+    for (int i = 0; i < len; ++i) {
+        //Čekanje dok TXE postane prazan
+        while (!(usart->SR & USART_SR_TXE));
+        //Upisivanje bajta u data registar
+        usart->DR = ptr[i];
+    }
+}
+
+void usart_init(USART_TypeDef* usart, uint32_t baudrate, USART_OVERSAMPLING oversampling = USART_OVERSAMPLING::OVERSAMPLING_16, USART_MODE mode = USART_MODE::BOTH)
+{
+    usart_clock_init(usart);
+    usart_set_state(usart, USART_STATE::DISABLE);
+    usart_configure_oversampling(usart, oversampling);
+    usart_set_baudrate(usart, baudrate);
+    usart_configure_mode(usart, mode);
+    usart_set_state(usart, USART_STATE::ENABLE);
+}

--- a/src/interns/demir-hasicic/USART.h
+++ b/src/interns/demir-hasicic/USART.h
@@ -1,0 +1,33 @@
+#include <stdint.h>
+#include "stm32f4xx.h"
+
+enum class USART_STATE {
+    DISABLE,
+    ENABLE
+};
+
+enum class USART_OVERSAMPLING {
+    OVERSAMPLING_16,
+    OVERSAMPLING_8
+};
+
+enum class PPRE {
+    DIV2 = 4,
+    DIV4 = 5,
+    DIV8 = 6,
+    DIV16 = 7
+};
+
+enum class USART_MODE {
+    TRANSMIT,
+    RECEIVE,
+    BOTH
+};
+
+void usart_clock_init(USART_TypeDef* usart);
+void usart_set_state(USART_TypeDef* usart, USART_STATE state);
+void usart_configure_oversampling(USART_TypeDef* usart, USART_OVERSAMPLING oversampling);
+void usart_set_baudrate(USART_TypeDef* usart, uint32_t baudrate);
+void usart_configure_mode(USART_TypeDef* usart, USART_MODE mode);
+void usart_write_byte(USART_TypeDef* usart, uint8_t byte);
+void usart_write_buffer(USART_TypeDef* usart, char *ptr, int len);

--- a/src/interns/demir-hasicic/syscalls.cpp
+++ b/src/interns/demir-hasicic/syscalls.cpp
@@ -1,0 +1,43 @@
+#include <sys/stat.h>
+#include <sys/times.h>
+#include "USART.h"
+#include "GPIO.h"
+
+extern "C" int _write(int file, char *ptr, int len) {
+  (void) file;
+  (void) ptr;
+  (void) len;
+  for (int i=0; i<len; ++i)
+  {
+    while (!(USART2->SR & USART_SR_TXE));
+    USART2->DR = ptr[i];
+  }
+    
+  return len;
+}
+
+extern "C" int _fstat(int fd, struct stat *st) {
+  (void) fd, (void) st;
+  return -1;
+}
+
+extern "C" void *_sbrk(int incr) {
+  extern char _end;
+  static unsigned char *heap = NULL;
+  unsigned char *prev_heap;
+  if (heap == NULL) heap = (unsigned char *) &_end;
+  prev_heap = heap;
+  heap += incr;
+  return prev_heap;
+}
+
+extern "C" int _read(int fd, char *ptr, int len) {
+  (void) fd, (void) ptr, (void) len;
+  return -1;
+}
+
+extern "C" int _close(int file) { return -1; }
+extern "C" int _isatty(int file) { return -1; }
+extern "C" int _lseek(int file, int ptr, int dir) { return 0; }
+extern "C" int _getpid(int file) {return -1;}
+extern "C" int _kill(int pid, int sig) {return -1;}


### PR DESCRIPTION
Includes : 
-Added USART functionality in USART.cpp and USART.h with functions for initializing usart, setting baudrate and enabling USART
-Added a "usart_init" function which combines the other USART initialization functions into one, improving usability
-Added a "gpio_init" function which combines the other GPIO initialization functions into one, improving usability
-Updated Makefile to include USART.cpp in the build process.
-Added syscalls.cpp to provide basic system call implementations